### PR TITLE
Add accessibility barrier logic after intent is assigned

### DIFF
--- a/intent_accessibility.py
+++ b/intent_accessibility.py
@@ -1,0 +1,34 @@
+import random
+
+class Person:
+    def __init__(self, location, intends_to_use_fp):
+        self.location = location  # 'urban' or 'rural'
+        self.intends_to_use_fp = intends_to_use_fp
+        self.can_reach_facility = False
+
+def check_accessibility(person, params):
+    """Determine whether a person can reach a facility based on location and barrier probability."""
+    if person.location == "urban":
+        return random.random() < params["urban_access_probability"]
+    else:
+        return random.random() < params["rural_access_probability"]
+
+# Example usage:
+params = {
+    "urban_access_probability": 0.95,
+    "rural_access_probability": 0.7
+}
+
+people = [
+    Person("urban", True),
+    Person("rural", True),
+    Person("urban", False)
+]
+
+for person in people:
+    if person.intends_to_use_fp:
+        person.can_reach_facility = check_accessibility(person, params)
+    else:
+        person.can_reach_facility = False
+
+    print(f"{person.location} | Intends: {person.intends_to_use_fp} | Can reach: {person.can_reach_facility}")

--- a/intent_accessibility.py
+++ b/intent_accessibility.py
@@ -1,4 +1,4 @@
-import random
+import random #to simulate chances or probabilities (like whether a person can reach a facility).
 
 class Person:
     def __init__(self, location, intends_to_use_fp):


### PR DESCRIPTION
This pull request adds a new feature that filters intenders by accessibility, simulating whether they can reach a facility. Accessibility is currently based on urban/rural status only.

Closes #3 